### PR TITLE
Fix carousel to not display many small columns

### DIFF
--- a/src/components/PersonsSection.jsx
+++ b/src/components/PersonsSection.jsx
@@ -1,12 +1,10 @@
 import React from 'react'
 import { persons } from '../assets/testimonials'
 import { useTranslation } from 'react-i18next'
-import SwiperCore, { Pagination, Navigation } from 'swiper/core'
-import { EffectCoverflow } from 'swiper/core'
+import SwiperCore, { Pagination, Navigation,Autoplay } from 'swiper/core'
 import { Swiper, SwiperSlide } from 'swiper/react'
 import useMediaQuery from '@material-ui/core/useMediaQuery'
 import 'swiper/swiper.min.css'
-import 'swiper/components/effect-coverflow/effect-coverflow.min.css'
 import 'swiper/components/pagination/pagination.min.css'
 import 'swiper/components/navigation/navigation.min.css'
 
@@ -48,7 +46,7 @@ const PersonsSection = () => {
     </>
   ))
 
-  SwiperCore.use([EffectCoverflow, Pagination, Navigation])
+  SwiperCore.use([ Pagination, Navigation,Autoplay])
   return (
     <>
       <div className='testimonials-container-persons'>
@@ -59,6 +57,10 @@ const PersonsSection = () => {
           centeredSlides={true}
           navigation={true}
           loop={true}
+          autoplay={{
+            "delay": 4000,
+            "disableOnInteraction": false
+          }}
           className='pagination'
           >
           <section>{listOfPersonCards}</section>

--- a/src/components/PersonsSection.jsx
+++ b/src/components/PersonsSection.jsx
@@ -10,9 +10,10 @@ import 'swiper/components/navigation/navigation.min.css'
 
 const PersonsSection = () => {
   const { t } = useTranslation()
-  const isPhone = useMediaQuery('(max-width:460px)')
-  const isTablet = useMediaQuery('(max-width:960px)')
-  const isBig = useMediaQuery('(max-width:1280px)')
+  const isPhone = useMediaQuery('(max-width:620px)')
+  const isTablet = useMediaQuery('(max-width:1280px)')
+  const isBig = useMediaQuery('(max-width:1920px)')
+
 
   const listOfPersonCards = persons.map((person, index) => (
     <>
@@ -51,10 +52,9 @@ const PersonsSection = () => {
     <>
       <div className='testimonials-container-persons'>
         <Swiper
-          slidesPerView={isPhone ? 1 : isTablet ? 1.5 : isBig ? 2 : 4}
+          slidesPerView={isPhone ? 1 : isTablet ? 2 : isBig ? 4 : 6}
           spaceBetween={30}
           grabCursor={true}
-          centeredSlides={true}
           navigation={true}
           loop={true}
           autoplay={{

--- a/src/components/PersonsSection.jsx
+++ b/src/components/PersonsSection.jsx
@@ -4,6 +4,7 @@ import { useTranslation } from 'react-i18next'
 import SwiperCore, { Pagination, Navigation } from 'swiper/core'
 import { EffectCoverflow } from 'swiper/core'
 import { Swiper, SwiperSlide } from 'swiper/react'
+import useMediaQuery from '@material-ui/core/useMediaQuery'
 import 'swiper/swiper.min.css'
 import 'swiper/components/effect-coverflow/effect-coverflow.min.css'
 import 'swiper/components/pagination/pagination.min.css'
@@ -11,6 +12,9 @@ import 'swiper/components/navigation/navigation.min.css'
 
 const PersonsSection = () => {
   const { t } = useTranslation()
+  const isPhone = useMediaQuery('(max-width:460px)')
+  const isTablet = useMediaQuery('(max-width:960px)')
+  const isBig = useMediaQuery('(max-width:1280px)')
 
   const listOfPersonCards = persons.map((person, index) => (
     <>
@@ -47,27 +51,16 @@ const PersonsSection = () => {
   SwiperCore.use([EffectCoverflow, Pagination, Navigation])
   return (
     <>
-      <div className='testimonials-container'>
+      <div className='testimonials-container-persons'>
         <Swiper
-          breakpoints={{
-            460: {
-              width: 460,
-              slidesPerView: 1,
-            },
-            720: {
-              slidesPerView: 1.5,
-            },
-            960: {
-              slidesPerView: 3,
-            },
-          }}
+          slidesPerView={isPhone ? 1 : isTablet ? 1.5 : isBig ? 2 : 4}
           spaceBetween={30}
           grabCursor={true}
           centeredSlides={true}
           navigation={true}
-          pagination={true}
           loop={true}
-          className='pagination'>
+          className='pagination'
+          >
           <section>{listOfPersonCards}</section>
         </Swiper>
       </div>

--- a/src/styles/_testimonialSlider2.scss
+++ b/src/styles/_testimonialSlider2.scss
@@ -36,8 +36,7 @@ section {
   background-size: cover;
   align-items: center;
   width: 300px;
-  min-height: 300px;
-  margin-bottom: 50px;
+  height: 100%;
   text-align: center;
   background-color: rgba(250, 245, 245, 0.541);
 }

--- a/src/styles/_testimonialSlider2.scss
+++ b/src/styles/_testimonialSlider2.scss
@@ -56,7 +56,6 @@ section {
   }
 }
 .swiper-container {
-  max-width: 1920px;
   height: 100%;
   p {
     font-size: 20px;

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -1102,8 +1102,7 @@ section {
       -ms-flex-align: center;
           align-items: center;
   width: 300px;
-  min-height: 300px;
-  margin-bottom: 50px;
+  height: 100%;
   text-align: center;
   background-color: rgba(250, 245, 245, 0.541);
 }

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -1124,7 +1124,6 @@ section {
 }
 
 .swiper-container {
-  max-width: 1920px;
   height: 100%;
 }
 


### PR DESCRIPTION
**PT-Story:**  https://www.pivotaltracker.com/story/show/178551596
### Descriptrion
``` 
When resizing from narrow screen to wide, slider glitches and shows to many very narrow cards
``` 
## Changes proposed in this pull request: 
* make it responsive when we change screen size
* adds auto-scroll animation after 4 sec
* removed breakpoints with use media query

## Video (Client) 

https://user-images.githubusercontent.com/79849155/122188496-4b5e0f00-ce90-11eb-8c75-4a2333a973a7.mp4

